### PR TITLE
Require yii only once

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -220,7 +220,7 @@ class Environment
         defined('YII_ENV_STAGE') or define('YII_ENV_STAGE', YII_ENV === 'stage');
 
         // Include Yii.
-        require($this->yiiPath);
+        require_once($this->yiiPath);
 
         // Set aliases.
         foreach ($this->aliases as $alias => $path) {


### PR DESCRIPTION
Hi!
Thanks for the great solution, but we encountered a problem, when we try to create couple of Environment classes.
The error we were getting is `Fatal error: Cannot declare class Yii, because the name is already in use`, and after some debugging we've figured out, that Environment class uses `require($this->yiiPath)` instead of `require_once($this->yiiPath)`.
If this change wouldn't break anything, I would highly appreciate merging it to master and releasing new version with this "fix" so we can get rid of overriden version of this class in our project