### PR TITLE
Supports alias mode names and `review/*` env for gitlab-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Use yii
 export YII_ENV='dev' && ./yii
 ```
 
+Supports `review/$CI_COMMIT_REF_NAME` environment name for gitlab-ci
+
+```
+export YII_ENV=$CI_ENVIRONMENT_NAME && ./yii
+```
+
 ## Documentation
 
 See `examples/`.

--- a/examples/config/mode_review.php
+++ b/examples/config/mode_review.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Review configuration.
+ */
+return [
+    // Web application configuration.
+    'web'=>[
+        'components' => [
+            'db' => [
+                'class' => 'yii\db\Connection',
+                'dsn' => 'mysql:host=localhost;dbname=yii2basic',
+                'username' => 'root',
+                'password' => '',
+                'charset' => 'utf8',
+            ],
+            'mailer' => [
+                'class' => 'yii\swiftmailer\Mailer',
+                'transport' => [
+                    'class' => 'Swift_SendmailTransport',
+                ],
+            ],
+        ],
+        'params' => [
+            'key' => 'value5',
+        ],
+    ],
+
+    // Console application configuration.
+    'console'=>[
+        'components' => [
+            'db' => [
+                'class' => 'yii\db\Connection',
+                'dsn' => 'mysql:host=localhost;dbname=yii2basic',
+                'username' => 'root',
+                'password' => '',
+                'charset' => 'utf8',
+            ],
+        ],
+        'params' => [
+            'key' => 'value5',
+        ],
+    ],
+];

--- a/examples/config/mode_review_new_branch.php
+++ b/examples/config/mode_review_new_branch.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * New branch review configuration.
+ */
+return [
+    // Web application configuration.
+    'web'=>[
+        'components' => [
+        ],
+        'params' => [
+            'key' => 'value6',
+        ],
+    ],
+
+    // Console application configuration.
+    'console'=>[
+        'components' => [
+        ],
+        'params' => [
+            'key' => 'value6',
+        ],
+    ],
+];


### PR DESCRIPTION
1. Add alias mode names such as GitLab style environment names:
    - `development` --> `dev`
    - `testing` --> `test`
    - `staging` --> `stage`
    - `production` --> `prod`
2. Add `review` mode for `review/*` env with sub mode config